### PR TITLE
Update Samples to use release version over RC version.. Pending release nuget

### DIFF
--- a/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingQueueClient/BasicSendReceiveUsingQueueClient.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingQueueClient/BasicSendReceiveUsingQueueClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingQueueClient/readme.md
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingQueueClient/readme.md
@@ -48,7 +48,7 @@ quickly or the scenarios where they need basic send/receive and wants to achieve
 1. Add the following to your project.json, making sure that the solution references the `Microsoft.Azure.ServiceBus` project.
 
     ```json
-    "Microsoft.Azure.ServiceBus": "1.0.0-RC1"
+    "Microsoft.Azure.ServiceBus": "1.0.0"
     ```
 
 ### Write some code to send and receive messages from the queue

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingTopicSubscriptionClient/BasicSendReceiveUsingTopicSubscriptionClient.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSendReceiveUsingTopicSubscriptionClient/BasicSendReceiveUsingTopicSubscriptionClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSessionSendReceiveUsingQueueClient/BasicSessionSendReceiveUsingQueueClient.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSessionSendReceiveUsingQueueClient/BasicSessionSendReceiveUsingQueueClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSessionSendReceiveUsingQueueClient/readme.md
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/BasicSessionSendReceiveUsingQueueClient/readme.md
@@ -50,7 +50,7 @@ or the scenarios where they need basic session based send/receive and wants to a
 1. Add the following to your project.json, making sure that the solution references the `Microsoft.Azure.ServiceBus` project.
 
     ```json
-    "Microsoft.Azure.ServiceBus": "1.0.0-RC1"
+    "Microsoft.Azure.ServiceBus": "1.0.0"
     ```
 
 ### Write some code to send and receive messages from the queue

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SendReceiveUsingMessageSenderReceiver/SendReceiveUsingMessageSenderReceiver.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SendReceiveUsingMessageSenderReceiver/SendReceiveUsingMessageSenderReceiver.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SendReceiveUsingMessageSenderReceiver/readme.md
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SendReceiveUsingMessageSenderReceiver/readme.md
@@ -46,7 +46,7 @@ to write more code to renew message locks, complete messages and define how to a
 1. Add the following to your project.json, making sure that the solution references the `Microsoft.Azure.ServiceBus` project.
 
     ```json
-    "Microsoft.Azure.ServiceBus": "1.0.0-RC1"
+    "Microsoft.Azure.ServiceBus": "1.0.0"
     ```
 
 ### Write some code to send and receive messages from the queue

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SessionSendReceiveUsingSessionClient/SessionSendReceiveUsingSessionClient.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SessionSendReceiveUsingSessionClient/SessionSendReceiveUsingSessionClient.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SessionSendReceiveUsingSessionClient/readme.md
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SessionSendReceiveUsingSessionClient/readme.md
@@ -48,7 +48,7 @@ define how to achieve a basic degree of concurrency while processing sessions.
 1. Add the following to your project.json, making sure that the solution references the `Microsoft.Azure.ServiceBus` project.
 
     ```json
-    "Microsoft.Azure.ServiceBus": "1.0.0-RC1"
+    "Microsoft.Azure.ServiceBus": "1.0.0"
     ```
 
 ### Write some code to send and receive messages from the queue

--- a/samples/DotNet/Microsoft.Azure.ServiceBus/TopicSubscriptionWithRuleOperationsSample/TopicSubscriptionWithRuleOperationsSample.csproj
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/TopicSubscriptionWithRuleOperationsSample/TopicSubscriptionWithRuleOperationsSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0-RC1" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updating samples to use Release version instead of the RC Version.. Keeping this open until Release is pushed to nuget

Fixes this issue:
https://github.com/Azure/azure-service-bus/issues/54