### PR TITLE
Fix minor typo in readme link

### DIFF
--- a/samples/DotNet/Microsoft.ServiceBus.Messaging/QueuesGettingStarted/README.md
+++ b/samples/DotNet/Microsoft.ServiceBus.Messaging/QueuesGettingStarted/README.md
@@ -10,7 +10,7 @@ Refer to the main [README](../README.md) document for setup instructions.
 
 ## Sample Code 
 
-The sample is documented inline in the [Program.cs](Program.cs) C# file.
+The sample is documented inline in the [program.cs](program.cs) C# file.
 
 To keep things reasonably simple, the sample program keeps message sender and
 message receiver code within a single hosting application, even though these


### PR DESCRIPTION
Link was pointing to Program.cs instead of program.cs resulting in a 404