### PR TITLE
Fix path to QueuesGettingStarted.java file

### DIFF
--- a/samples/Java/azure-servicebus/QueuesGettingStarted/readme.md
+++ b/samples/Java/azure-servicebus/QueuesGettingStarted/readme.md
@@ -10,7 +10,7 @@ Refer to the main [README](../README.md) document for setup instructions.
 
 ## Sample Code 
 
-The sample is documented inline in the [QueuesGettingStarted.java](.\src\main\java\com\microsoft\azure\servicebus\samples\queuesgettingstarted\QueuesGettingStarted.java) file.
+The sample is documented inline in the [QueuesGettingStarted.java](./src/main/java/com/microsoft/azure/servicebus/samples/queuesgettingstarted/QueuesGettingStarted.java) file.
 
 To keep things reasonably simple, the sample program keeps message sender and
 message receiver code within a single hosting application, even though these


### PR DESCRIPTION
## Description

The link to the QueuesGettingStarted.java file currently contains backslashes which causes a 404 on Github. Here is the link that causes the issue: https://github.com/Azure/azure-service-bus/blob/master/samples/Java/azure-servicebus/QueuesGettingStarted/.%5Csrc%5Cmain%5Cjava%5Ccom%5Cmicrosoft%5Cazure%5Cservicebus%5Csamples%5Cqueuesgettingstarted%5CQueuesGettingStarted.java

Replacing the backslashes with forward slashes as in this pull request fixes the problem.
This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] If applicable, the code is properly documented.
- [x] The code builds without any errors.