### PR TITLE
Removing unnecessary JNDI usage.

### DIFF
--- a/samples/Java/qpid-jms-client/JmsQueueQuickstart/.classpath
+++ b/samples/Java/qpid-jms-client/JmsQueueQuickstart/.classpath
@@ -10,6 +10,7 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
@@ -25,6 +26,23 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/samples/Java/qpid-jms-client/JmsQueueQuickstart/src/test/java/com/microsoft/azure/servicebus/samples/jmsqueuequickstart/JmsQueueQuickstartTest.java
+++ b/samples/Java/qpid-jms-client/JmsQueueQuickstart/src/test/java/com/microsoft/azure/servicebus/samples/jmsqueuequickstart/JmsQueueQuickstartTest.java
@@ -17,5 +17,4 @@ public class JmsQueueQuickstartTest {
                     }
                 }));
     }
-
 }


### PR DESCRIPTION
## Description
The current sample (and documentation) unnecessarily uses JNDI to configure the connection factory. This adds unnecessary complexity and confusion. Younger users may not even know what JNDI is. I've rewritten the queue sample to work without creating a JNDI context.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [V ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [V ] Title of the pull request is clear and informative.
- [V] If applicable, the code is properly documented.
- [V] The code builds without any errors.