### PR TITLE
SessionState Sample CompleteAsync used a NULL object

### DIFF
--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SessionState/Program.cs
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SessionState/Program.cs
@@ -186,7 +186,7 @@ namespace SessionState
                                                     recipeStep.Title);
                                                 Console.ResetColor();
                                             }
-                                            await session.CompleteAsync(message.SystemProperties.LockToken);
+                                            await session.CompleteAsync(deferredMessage.SystemProperties.LockToken);
                                             processingState.LastProcessedRecipeStep = processingState.LastProcessedRecipeStep + 1;
                                             processingState.DeferredSteps.Remove(processingState.LastProcessedRecipeStep);
                                             await session.SetStateAsync(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(processingState)));


### PR DESCRIPTION
## Description
<!--
Azure service bus samples in Microsoft.Azure.ServiceBus\SessionState - Session CompleteAsync used a **message** object where it is null in ReceiveDeferredMessageAsync. 
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [OK ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ OK] Title of the pull request is clear and informative.
- [ OK] If applicable, the code is properly documented.
- [ OK] The code builds without any errors.