### PR TITLE
Use second argument in string formatting

### DIFF
--- a/samples/DotNet/Microsoft.Azure.ServiceBus/TopicsGettingStarted/Program.cs
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/TopicsGettingStarted/Program.cs
@@ -131,7 +131,7 @@ namespace TopicsGettingStarted
 
         private Task LogMessageHandlerException(ExceptionReceivedEventArgs e)
         {
-            Console.WriteLine("Exception: \"{0}\" {0}", e.Exception.Message, e.ExceptionReceivedContext.EntityPath);
+            Console.WriteLine("Exception: \"{0}\" {1}", e.Exception.Message, e.ExceptionReceivedContext.EntityPath);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
It is obvious from context that both arguments are supposed to be used. Right now first argument is used twice which is incorrect.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [ ] If applicable, the code is properly documented.
- [x] The code builds without any errors.