### PR TITLE
Typo, unused reference, and a couple other small corrections

### DIFF
--- a/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
+++ b/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
@@ -8,12 +8,12 @@ namespace BasicSendReceiveQuickStart
 {
     class Program
     {
-        static IQueueClient _queueClient;
+        static IQueueClient queueClient;
 
         static void Main(string[] args)
         {
-            string serviceBusConnectionString = string.Empty;
-            string queueName = string.Empty;
+            var serviceBusConnectionString = string.Empty;
+            var queueName = string.Empty;
 
             for (var i = 0; i < args.Length; i++)
             {
@@ -42,7 +42,7 @@ namespace BasicSendReceiveQuickStart
         static async Task MainAsync(string serviceBusConnectionString, string queueName)
         {
             const int numberOfMessages = 10;
-            _queueClient = new QueueClient(serviceBusConnectionString, queueName);
+            queueClient = new QueueClient(serviceBusConnectionString, queueName);
 
             Console.WriteLine("======================================================");
             Console.WriteLine("Press any key to exit after receiving all the messages.");
@@ -56,7 +56,7 @@ namespace BasicSendReceiveQuickStart
 
             Console.ReadKey();
 
-            await _queueClient.CloseAsync();
+            await queueClient.CloseAsync();
         }
 
         static void RegisterOnMessageHandlerAndReceiveMessages()
@@ -74,7 +74,7 @@ namespace BasicSendReceiveQuickStart
             };
 
             // Register the function that will process messages
-            _queueClient.RegisterMessageHandler(ProcessMessagesAsync, messageHandlerOptions);
+            queueClient.RegisterMessageHandler(ProcessMessagesAsync, messageHandlerOptions);
         }
 
         static async Task ProcessMessagesAsync(Message message, CancellationToken token)
@@ -84,7 +84,7 @@ namespace BasicSendReceiveQuickStart
 
             // Complete the message so that it is not received again.
             // This can be done only if the queueClient is created in ReceiveMode.PeekLock mode (which is default).
-            await _queueClient.CompleteAsync(message.SystemProperties.LockToken);
+            await queueClient.CompleteAsync(message.SystemProperties.LockToken);
 
             // Note: Use the cancellationToken passed as necessary to determine if the queueClient has already been closed.
             // If queueClient has already been Closed, you may chose to not call CompleteAsync() or AbandonAsync() etc. calls 
@@ -117,7 +117,7 @@ namespace BasicSendReceiveQuickStart
                     Console.WriteLine($"Sending message: {messageBody}");
 
                     // Send the message to the queue
-                    await _queueClient.SendAsync(message);
+                    await queueClient.SendAsync(message);
                 }
             }
             catch (Exception exception)

--- a/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
+++ b/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
@@ -17,7 +17,6 @@ namespace BasicSendReceiveQuickStart
 
             for (int i = 0; i < args.Length; i++)
             {
-                var p = new Program();
                 if (args[i] == "-ConnectionString")
                 {
                     Console.WriteLine($"ConnectionString: {args[i+1]}");
@@ -34,7 +33,7 @@ namespace BasicSendReceiveQuickStart
                 MainAsync(ServiceBusConnectionString, QueueName).GetAwaiter().GetResult();
             else
             {
-                Console.WriteLine("Specify -Connectionstring and -QueueName to execute the example.");
+                Console.WriteLine("Specify -ConnectionString and -QueueName to execute the example.");
                 Console.ReadKey();
             }                            
         }

--- a/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
+++ b/samples/DotNet/GettingStarted/BasicSendReceiveQuickStart/BasicSendReceiveQuickStart/Program.cs
@@ -30,7 +30,7 @@ namespace BasicSendReceiveQuickStart
                 }
             }
 
-            if (serviceBusConnectionString != "" && queueName != "")
+            if (!string.IsNullOrEmpty(serviceBusConnectionString) && !string.IsNullOrEmpty(queueName))
                 MainAsync(serviceBusConnectionString, queueName).GetAwaiter().GetResult();
             else
             {


### PR DESCRIPTION
## Description
This PR makes five total corrections:
1. Connectionstring -> ConnectionString 
The console message when you fail to specify either ConnectionString or QueueName is spelled "-Connectionstring". The argument parser is case-sensitive, so if you copy-paste the flag from the console window, the program will not run. 
2. Removed unused reference at line 20:
var p = new Program();
3. Changed the arguments parsing to use a switch block
4. Changed empty string references to their corresponding string methods. This includes initialization of strings to string.Empty and checking for empty strings to use string.IsNullOrEmpty().
5. Linting. Used var where possible, changed variable names to be context-appropriate.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] If applicable, the code is properly documented.
- [x] The code builds without any errors.