### PR TITLE
Changed EntityPath format for example with Topic/Subscription

### DIFF
--- a/samples/DotNet/Microsoft.Azure.ServiceBus/SendersReceiversWithTopics/README.md
+++ b/samples/DotNet/Microsoft.Azure.ServiceBus/SendersReceiversWithTopics/README.md
@@ -44,7 +44,7 @@ as we do with queues, but first format a path to the subscription from the topic
 the ```MessageReceiver``` using the composite path. From the ```MessageReceiver``` perspective, the resulting path is completely 
 interchangeable with any queue's path.
 
-The static helper method ```SubscriptionClient.FormatSubscriptionPath()``` returns a path of the form ```{topic-name}/Subscription/{subscription-name}```
+The static helper method ```SubscriptionClient.FormatSubscriptionPath()``` returns a path of the form ```{topic-name}/Subscriptions/{subscription-name}```
 
 ``` C#
 >       var subscriptionPath = SubscriptionClient.FormatSubscriptionPath(topicName, subscriptionName);


### PR DESCRIPTION
The Entity path Format was previous {topic-name}/Subscription/{subscription-name} this caused errors when the client was trying to connect to the service. 

The correct format should be {topic-name}/Subscriptions/{subscription-name}



This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] If applicable, the code is properly documented.
- [x] The code builds without any errors.