### PR TITLE
Client SDKs info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This repository is intended to be used for the following:
 * [Samples](./samples/readme.md)
 * Reports of documentation issues
 
-If you are looking for the code of a specific client library, see the following:
-* [.NET Standard](https://github.com/Azure/azure-sdk-for-net/)
-* [Java](https://github.com/azure/azure-service-bus-java)
+If you are looking for the code of a specific **client library**, see the following link for all language specific SDKs: https://github.com/Azure/azure-sdk
 
 ## How to provide feedback
 


### PR DESCRIPTION
This repo is confused by many with client SDKs. Adding a link to specifically call out Azure SDKs (@azure-sdk) to help Python, Go, Node.js, .NET, Java folks to locate the right issue trackers.

@axisc FYI