### PR TITLE
Update QueuesWithProxy.java

### DIFF
--- a/samples/Java/azure-servicebus/QueuesWithProxy/src/main/java/com/microsoft/azure/servicebus/samples/queueswithproxy/QueuesWithProxy.java
+++ b/samples/Java/azure-servicebus/QueuesWithProxy/src/main/java/com/microsoft/azure/servicebus/samples/queueswithproxy/QueuesWithProxy.java
@@ -218,7 +218,7 @@ public class QueuesWithProxy {
         String output = null;
 
         if (cl.getOptionValue(optionValue) != null) {
-            output = cl.getOptionValue("c");
+            output = cl.getOptionValue(optionValue);
         }
 
         // get overrides from the environment


### PR DESCRIPTION
method getOptionOrEnv was always retrieving the port number incorrectly

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] If applicable, the code is properly documented.
- [ ] The code builds without any errors.