### PR TITLE
Make the link to the other SDKs point to the general Azure SDK repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This repository is intended to be used for the following:
 * [Samples](./samples/readme.md)
 * Reports of documentation issues
 
-If you are looking for the code of a specific client library, see the following:
-* [.NET Standard](https://github.com/Azure/azure-sdk-for-net/)
-* [Java](https://github.com/azure/azure-service-bus-java)
+If you are looking for the code of a specific client library, see the following for a list of available libraries in each supported language: [link](https://github.com/Azure/azure-sdk)
 
 ## How to provide feedback
 


### PR DESCRIPTION
The readme is pointing to only a couple of repos, but we have Service Bus support in 5 languages now: C#, Java, JavaScript, Python and also Go. Since that list will just continue to grow it seems easiest to just point to the general azure-sdk page, rather than list all the languages explicitly.

Fixes Azure/azure-sdk-for-go/issues/16198